### PR TITLE
remove disabled api key + remove default dataset from otelcol-config

### DIFF
--- a/src/otelcollector/otelcol-config-extras.yml
+++ b/src/otelcollector/otelcol-config-extras.yml
@@ -8,7 +8,7 @@ exporters:
   otlp/honeycomb:
     endpoint: "api.honeycomb.io:443"
     headers:
-      "x-honeycomb-team": "hcaik_01hymsbngwwvjgcfgmpg6r4q82"
+      "x-honeycomb-team": ""
       "x-honeycomb-dataset": "webstore-metrics"
       
 service:


### PR DESCRIPTION
# Changes

Removed reference to a deleted testing api key & removed the default dataset name for web data. 

